### PR TITLE
Add thrift 0.9.3 Formula

### DIFF
--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -1,0 +1,89 @@
+class Thrift < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org/"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.cgi?path=/thrift/0.9.3/thrift-0.9.3.tar.gz"
+    sha256 "b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e"
+
+    # Apply any necessary patches (none currently required)
+    [
+      # Example patch:
+      #
+      # Apply THRIFT-2201 fix from master to 0.9.1 branch (required for clang to compile with C++11 support)
+      # %w{836d95f9f00be73c6936d407977796181d1a506c f8e14cbae1810ade4eab49d91e351459b055c81dba144c1ca3c5d6f4fe440925},
+    ].each do |name, sha|
+      patch do
+        url "https://git-wip-us.apache.org/repos/asf?p=thrift.git;a=commitdiff_plain;h=#{name}"
+        sha256 sha
+      end
+    end
+  end
+
+  bottle do
+    cellar :any
+    rebuild 1
+    sha256 "f3bd35df2ba94af77f15a836668db5eb7dfc0d37c77a2f77bc6cc980e1524f27" => :sierra
+    sha256 "528061b3a3689341d76d76a7faaa6345100bbbadeb4055a26f1acb6377aad3ba" => :el_capitan
+    sha256 "7b1c9edc94356d9cb426237fab09143c64d2bb2a85d86f7d8236702fa110f90c" => :yosemite
+  end
+
+  head do
+    url "https://git-wip-us.apache.org/repos/asf/thrift.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "pkg-config" => :build
+  end
+
+  option "with-haskell", "Install Haskell binding"
+  option "with-erlang", "Install Erlang binding"
+  option "with-java", "Install Java binding"
+  option "with-perl", "Install Perl binding"
+  option "with-php", "Install PHP binding"
+  option "with-libevent", "Install nonblocking server libraries"
+
+  depends_on "bison" => :build
+  depends_on "boost"
+  depends_on "openssl"
+  depends_on "libevent" => :optional
+  depends_on :python => :optional
+
+  def install
+    system "./bootstrap.sh" unless build.stable?
+
+    exclusions = ["--without-ruby", "--disable-tests", "--without-php_extension"]
+
+    exclusions << "--without-python" if build.without? "python"
+    exclusions << "--without-haskell" if build.without? "haskell"
+    exclusions << "--without-java" if build.without? "java"
+    exclusions << "--without-perl" if build.without? "perl"
+    exclusions << "--without-php" if build.without? "php"
+    exclusions << "--without-erlang" if build.without? "erlang"
+
+    ENV.cxx11 if MacOS.version >= :mavericks && ENV.compiler == :clang
+
+    # Don't install extensions to /usr:
+    ENV["PY_PREFIX"] = prefix
+    ENV["PHP_PREFIX"] = prefix
+
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--libdir=#{lib}",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}",
+                          *exclusions
+    ENV.deparallelize
+    system "make"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    To install Ruby binding:
+      gem install thrift
+
+    To install PHP extension for e.g. PHP 5.5:
+      brew install homebrew/php/php55-thrift
+  EOS
+  end
+end


### PR DESCRIPTION
This formula for the legacy thrift version was last updated in Dec
2016, but apparently dropped from homebrew-core in 2017.

The iOS app is currently locked to version 0.9.3, as it's the last
all obj-c thrift version. 0.10 and 0.11 use obj-c/swift 2, which our
app project can't use because it's a swift 4 project.

https://github.com/Homebrew/homebrew-core/blob/9d524e4850651cfedd64bc0740f1379b533f607d/Formula/thrift.rb