### PR TITLE
Create a cask which represents our base packages

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -1,6 +1,6 @@
 cask 'gu-base' do 
   version '0.0.1'
-  sha256 :nocheck
+  sha256 :no_check
 
   name 'Guardian Base'
   homepage 'https://github.com/guardian/homebrew-devtools'

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -47,5 +47,4 @@ cask 'gu-base' do
   depends_on cask: 'postman'
   depends_on cask: 'vlc'
 
-
 end

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -1,0 +1,7 @@
+cask 'gu-base' do 
+  version '0.0.1'
+
+  name 'Guardian Base'
+
+  depends_on cask: 'intellij-idea'
+  depends_on formula: 'guardian/devtools/ssm'

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -3,6 +3,45 @@ cask 'gu-base' do
 
   name 'Guardian Base'
 
+  # main applications
+  depends_on formula:  'openssl'
+  depends_on formula:  'mas'
+  depends_on formula:  'wget'
+  depends_on formula:  'ack'
+  depends_on formula:  'jq'
+  depends_on formula:  'bash-completion'
+  depends_on formula:  'coreutils'
+  depends_on formula:  'git'
+  depends_on formula:  'hub'
+  depends_on formula:  'gnupg'
+  depends_on formula:  'htop'
+  depends_on formula:  'mtr'
+  depends_on formula:  'tree'
+  depends_on formula:  'unrar'
+  depends_on formula:  'watch'
+
+  # dev langs
+  depends_on cask: 'caskroom/versions/java8'
+  depends_on formula:  'scala'
+  depends_on formula:  'sbt'
+  depends_on formula:  'node'
+  depends_on formula:  'yarn'
+
+  # guardian stuff
+  depends_on formula:  'guardian/devtools/ssm'
+
+  # gui apps
+  depends_on cask: 'keepingyouawake'
+  depends_on cask: 'google-chrome'
+  depends_on cask: 'iterm2'
+  depends_on cask: 'caskroom/versions/firefoxdeveloperedition'
+  depends_on cask: 'dropbox'
+  depends_on cask: 'visualvm'
   depends_on cask: 'intellij-idea'
-  depends_on formula: 'guardian/devtools/ssm'
+  depends_on cask: 'visual-studio-code'
+  depends_on cask: 'gpg-suite'
+  depends_on cask: 'postman'
+  depends_on cask: 'vlc'
+
+
 end

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -39,7 +39,6 @@ cask 'gu-base' do
   depends_on cask: 'google-chrome'
   depends_on cask: 'iterm2'
   depends_on cask: 'caskroom/versions/firefoxdeveloperedition'
-  depends_on cask: 'dropbox'
   depends_on cask: 'visualvm'
   depends_on cask: 'intellij-idea'
   depends_on cask: 'visual-studio-code'

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -5,3 +5,4 @@ cask 'gu-base' do
 
   depends_on cask: 'intellij-idea'
   depends_on formula: 'guardian/devtools/ssm'
+end

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -7,7 +7,6 @@ cask 'gu-base' do
   url 'https://github.com/guardian/homebrew-devtools'
   stage_only true
 
-
   # main applications
   depends_on formula:  'openssl'
   depends_on formula:  'mas'

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -1,7 +1,12 @@
 cask 'gu-base' do 
   version '0.0.1'
+  sha256 :nocheck
 
   name 'Guardian Base'
+  homepage 'https://github.com/guardian/homebrew-devtools'
+  url 'https://github.com/guardian/homebrew-devtools'
+  stage_only true
+
 
   # main applications
   depends_on formula:  'openssl'


### PR DESCRIPTION
Rather than making changes to strap, I was thinking that the best way of specifying our dependencies was to have a Cask that we can install. 

```sh
brew cask install guardian/devtools/gu-base
```