### PR TITLE
Add awscli and nginx to gu-base apps

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -23,6 +23,8 @@ cask 'gu-base' do
   depends_on formula:  'tree'
   depends_on formula:  'unrar'
   depends_on formula:  'watch'
+  depends_on formula:  'awscli'
+  depends_on formula:  'nginx'
 
   # dev langs
   depends_on cask: 'caskroom/versions/java8'


### PR DESCRIPTION
I have a new dev machine, the steps I followed were:

1. get strap
2. brew cask install caskroom/versions/java8
3. brew cask install guardian/devtools/gu-base

✨ 🚀 This was wonderful and straightforward, however there were a couple of useful applications that I had to subsequently install:

```
brew install awscli
brew install nginx
```

Since all devs will probably need `awscli` the first time they try to get credentials via Janus, and most will want to use `nginx` at some point, adding them to the gu-base would be helpful!

@AWare

