### PR TITLE
Remove the legacy reference to the versioned casks tap

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -38,7 +38,7 @@ cask 'gu-base' do
   # gui apps
   depends_on cask: 'keepingyouawake'
   depends_on cask: 'iterm2'
-  depends_on cask: 'caskroom/versions/firefox-developer-edition'
+  depends_on cask: 'homebrew/cask-versions/firefox-developer-edition'
   depends_on cask: 'visualvm'
   depends_on cask: 'intellij-idea'
   depends_on cask: 'visual-studio-code'


### PR DESCRIPTION
See https://github.com/caskroom