### PR TITLE
ssm-scala version 1.5.0

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "1.4.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v1.4.0/ssm.tar.gz"
-  sha256 "e1227f9eee6da542b09de80011de6edf8c54ab3bd89b04997110c3e8913c402e"
+  version "1.5.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v1.5.0/ssm.tar.gz"
+  sha256 "20bd773e76f02de3276c9422da7a24b9ab296f27b5468ceea9677f9e9dbbe6ba"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
Companion PR for https://github.com/guardian/ssm-scala/releases/tag/v1.5.0