### PR TITLE
bump dev-nginx version

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.0.0"
-  url "https://github.com/guardian/dev-nginx/archive/v1.0.0.tar.gz"
-  sha256 "4388b63823f1df56f203d8fcc3be1f48a67da7e92dc5adcbec8fdb18263ffe9e"
+  version "1.0.1"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.0.1/dev-nginx.tar.gz"
+  sha256 "15fb4a1df24e98677bd6c4a2c3afea6190b7f2da2f146dbf13f32e1c12d96747"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
also move to releases url (see https://github.com/guardian/dev-nginx/releases/tag/v1.0.1)