### PR TITLE
Remove adoptopenjdk cask

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -27,7 +27,6 @@ cask 'gu-base' do
   depends_on formula:  'nginx'
 
   # dev langs
-  depends_on cask:     'AdoptOpenJDK/openjdk/adoptopenjdk8'
   depends_on cask:     'gu-scala'
   depends_on formula:  'node'
   depends_on formula:  'yarn'


### PR DESCRIPTION
I'm pretty sure this is now included in default homebrew so we don't need this step anymore (and it currently results in homebrew not being sure where to get the jdk from I think)