### PR TITLE
Fix ophan compilation issues by reverting to using Java 8

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -27,7 +27,7 @@ cask 'gu-base' do
   depends_on formula:  'nginx'
 
   # dev langs
-  depends_on cask:     'adoptopenjdk'
+  depends_on cask:     'adoptopenjdk/openjdk/adoptopenjdk8'
   depends_on cask:     'gu-scala'
   depends_on formula:  'node'
   depends_on formula:  'yarn'


### PR DESCRIPTION
Change made in relation to https://github.com/guardian/homebrew-devtools/issues/42#issuecomment-539429576

Ophan was failing to compile locally using Java version 13. The compilation error `type Generated is not a member of package javax.annotation` was raised when compiling Scrooge from Twitter. 

An issue raised on the scrooge repo https://github.com/twitter/scrooge/issues/299 deals with the same problem and was solved in that case by Twitter adding Java version 11 support if Scrooge version >=19.6.0 is used, which is something Ophan could do. However, Scala support for JDK11 is incomplete. See https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-11-compatibility-notes. With this in mind defaulting to OpenJDK8 is probably safer for the laptop setup script.

Testing was done locally by uninstalling java and then running 
```bash
brew cask install Casks/gu-base.rb
```

 

