### PR TITLE
SSM Scala v1.6.0

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -2,7 +2,7 @@ class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
   version "1.6.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v1.5.0/ssm.tar.gz"
+  url "https://github.com/guardian/ssm-scala/releases/download/v1.6.0/ssm.tar.gz"
   sha256 "2ffb136dd67b68b2d85abe6efd386b981c70c4fca1ec69efb92b21d5c11c6e76"
 
   def install

--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -3,7 +3,7 @@ class Ssm < Formula
   homepage "https://github.com/guardian/ssm-scala"
   version "1.6.0"
   url "https://github.com/guardian/ssm-scala/releases/download/v1.5.0/ssm.tar.gz"
-  sha256 "20bd773e76f02de3276c9422da7a24b9ab296f27b5468ceea9677f9e9dbbe6ba"
+  sha256 "2ffb136dd67b68b2d85abe6efd386b981c70c4fca1ec69efb92b21d5c11c6e76"
 
   def install
     bin.install "ssm"

--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,7 +1,7 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "1.5.0"
+  version "1.6.0"
   url "https://github.com/guardian/ssm-scala/releases/download/v1.5.0/ssm.tar.gz"
   sha256 "20bd773e76f02de3276c9422da7a24b9ab296f27b5468ceea9677f9e9dbbe6ba"
 


### PR DESCRIPTION
Version bump to include https://github.com/guardian/ssm-scala/pull/111