### PR TITLE
Add formula for installing vpn

### DIFF
--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -1,6 +1,6 @@
 class GuVpn < Formula
   
-    desc "Shiny new formula"
+    desc "Formula for guardian vpn access using openconnect and vpn-slice script"
     homepage "https://github.com/guardian/homebrew-devtools"
     version "1"
     url "https://gist.githubusercontent.com/philmcmahon/d5b17e0217d35c2d008a11453cf66602/raw/8735a5fad4bed60efd4f3b63d464925b1785d01c/run-vpn.sh"

--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -3,8 +3,8 @@ class GuVpn < Formula
     desc "Formula for guardian vpn access using openconnect and vpn-slice script"
     homepage "https://github.com/guardian/homebrew-devtools"
     version "1"
-    url "https://gist.githubusercontent.com/philmcmahon/d5b17e0217d35c2d008a11453cf66602/raw/8735a5fad4bed60efd4f3b63d464925b1785d01c/run-vpn.sh"
-    sha256 "236684489d42035c90e70eb868fe157f0c4502263c63c876ffd847e808dde414"
+    url "https://raw.githubusercontent.com/guardian/homebrew-devtools/pm-vpn-formula/scripts/run-vpn.sh"
+    sha256 "395e1e703e1dc3f074c49f83a96bec7fa8887e4b15674f258ef72e7180eef5ab"
   
     depends_on "openconnect"
     depends_on "bind"

--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -1,0 +1,18 @@
+class GuVpn < Formula
+  
+    desc "Shiny new formula"
+    homepage "https://github.com/guardian/homebrew-devtools"
+    version "1"
+    url "https://gist.githubusercontent.com/philmcmahon/d5b17e0217d35c2d008a11453cf66602/raw/8735a5fad4bed60efd4f3b63d464925b1785d01c/run-vpn.sh"
+    sha256 "236684489d42035c90e70eb868fe157f0c4502263c63c876ffd847e808dde414"
+  
+    depends_on "openconnect"
+    depends_on "bind"
+    depends_on "pyenv"
+  
+    def install
+        mv "run-vpn.sh", "gvpn"
+        bin.install "gvpn"    
+    end
+  
+  end

--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -3,7 +3,7 @@ class GuVpn < Formula
     desc "Formula for guardian vpn access using openconnect and vpn-slice script"
     homepage "https://github.com/guardian/homebrew-devtools"
     version "1"
-    url "https://raw.githubusercontent.com/guardian/homebrew-devtools/pm-vpn-formula/scripts/run-vpn.sh"
+    url "https://raw.githubusercontent.com/guardian/homebrew-devtools/master/scripts/run-vpn.sh"
     sha256 "395e1e703e1dc3f074c49f83a96bec7fa8887e4b15674f258ef72e7180eef5ab"
   
     depends_on "openconnect"

--- a/scripts/run-vpn.sh
+++ b/scripts/run-vpn.sh
@@ -2,14 +2,16 @@
 function join { local IFS="$1"; shift; echo "$*"; }
 
 DOMAINS=(
-	'teamcity.gutools.co.uk'
-	'janus.gutools.co.uk'
-	'riffraff.gutools.co.uk'
-	'metrics.gutools.co.uk'
+    'teamcity.gutools.co.uk'
+    'janus.gutools.co.uk'
+    'riffraff.gutools.co.uk'
+    'metrics.gutools.co.uk'
     'amiable.gutools.co.uk'
     'amigo.gutools.co.uk'
     'prism.gutools.co.uk'
-	)
+    'security-hq.gutools.co.uk'
+    'zerobin.gutools.co.uk'
+)
 
 DOMAINS_STRING=$(join ' ' ${DOMAINS[@]})
 

--- a/scripts/run-vpn.sh
+++ b/scripts/run-vpn.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+function join { local IFS="$1"; shift; echo "$*"; }
+
+DOMAINS=(
+	'teamcity.gutools.co.uk'
+	'janus.gutools.co.uk'
+	'riffraff.gutools.co.uk'
+	'metrics.gutools.co.uk'
+    'amiable.gutools.co.uk'
+    'amigo.gutools.co.uk'
+    'prism.gutools.co.uk'
+	)
+
+DOMAINS_STRING=$(join ' ' ${DOMAINS[@]})
+
+echo "Setting up VPN for these domains: ${DOMAINS_STRING}"
+
+pyenv install 3.7.2 -s
+pyenv shell 3.7.2
+pip3 install vpn-slice
+openconnect https://digivpn.theguardian.com -s "vpn-slice ${DOMAINS_STRING}"

--- a/scripts/run-vpn.sh
+++ b/scripts/run-vpn.sh
@@ -15,9 +15,12 @@ DOMAINS=(
 
 DOMAINS_STRING=$(join ' ' ${DOMAINS[@]})
 
-echo "Setting up VPN for these domains: ${DOMAINS_STRING}"
 
 pyenv install 3.7.2 -s
 pyenv shell 3.7.2
-pip3 install vpn-slice
+pip3 install vpn-slice -q --disable-pip-version-check
+
+echo ""
+echo "Setting up VPN for these domains: ${DOMAINS_STRING}"
+
 openconnect https://digivpn.theguardian.com -s "vpn-slice ${DOMAINS_STRING}"


### PR DESCRIPTION
@AWare discovered that we can use open connect and https://github.com/dlenski/vpn-slice to do split tunelling via hostname on the VPN. This means that we can connect to the vpn but only traffic to a set of domains we specify will go over the vpn. The vpn-slice script essentially does a load of `dig` commands to get the IP addresses of the load balancers behind e.g. janus.gutools. So if the ELB decides to change ip address the traffic will no longer go over the vpn, but restarting this script should solve the problem.

The idea with this cask is that people should be able to run

```
brew install `guardian/devtools/gu-vpn`
sudo gvpn
```

they'll have to fill out their guardian credentials and OTP password then they'll be connected. They'll then have to leave that terminal window open - this seems to make more sense than running in the background so that people have som visibility of being connected

The actual connection stuff happens in this script - which brew installs with the alias `gvpn` https://gist.githubusercontent.com/philmcmahon/d5b17e0217d35c2d008a11453cf66602/raw/8735a5fad4bed60efd4f3b63d464925b1785d01c/run-vpn.sh