### PR TITLE
add session-manager-plugin

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -48,5 +48,6 @@ cask 'gu-base' do
   depends_on cask: 'vlc'
   depends_on cask: 'spectacle'
   depends_on cask: 'licecap'
+  depends_on cask: 'session-manager-plugin'
 
 end


### PR DESCRIPTION
## What does this change?
As noted by ssm-scala, session-manager-plugin is needed https://github.com/guardian/ssm-scala#on-your-machine. Install it as part of the standard set of tools.

## How can we measure success?
Simpler devx.

## Images
n/a