### PR TITLE
Update gu-base.rb

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -9,7 +9,6 @@ cask 'gu-base' do
 
   # main applications
   depends_on formula:  'openssl'
-  depends_on formula:  'mas'
   depends_on formula:  'wget'
   depends_on formula:  'ack'
   depends_on formula:  'jq'


### PR DESCRIPTION
Removing mas as a dependency as the following error is being thrown when running strap
`Error: No available formula with the name "mas"`