### PR TITLE
Update dev-nginx.rb

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.1.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.1.0/dev-nginx.tar.gz"
-  sha256 "816804fdf6d0bbdc9ca8cdc6ff58db88e8e24f2e6dfe4f481d8950cda4171486"
+  version "1.1.1"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.1.1/dev-nginx.tar.gz"
+  sha256 "64a20567ec209a410906fb8a3fa55e6b0740198ca2f5cb9ee465cee92b34b025"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
Bump to latest release of dev-nginx - https://github.com/guardian/dev-nginx/releases/tag/v1.1.1.