### PR TITLE
SSM version 2!

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -2,8 +2,8 @@ class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
   version "2.0.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v1.7.0/ssm.tar.gz"
-  sha256 "4a27d806b52ad70ab746e3ba7be7c2f74196f7f498ac6c36a10ddc58f28048d3"
+  url "https://github.com/guardian/ssm-scala/releases/download/v2.0.0/ssm.tar.gz"
+  sha256 "e3de789dbf0ebe8e40911150ea78f08492d98e54c5211fb2adf283688a68ceea"
 
   def install
     bin.install "ssm"

--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,7 +1,7 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "1.7.0"
+  version "2.0.0"
   url "https://github.com/guardian/ssm-scala/releases/download/v1.7.0/ssm.tar.gz"
   sha256 "4a27d806b52ad70ab746e3ba7be7c2f74196f7f498ac6c36a10ddc58f28048d3"
 


### PR DESCRIPTION
This updates homebrew-devtools to use the latest version of SSM as detailed here https://github.com/guardian/ssm-scala/releases/tag/v2.0.0 - the main new 'feature' being that ssm-tunnel is now the default behaviour