### PR TITLE
new version of dev-nginx

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.1.1"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.1.1/dev-nginx.tar.gz"
-  sha256 "64a20567ec209a410906fb8a3fa55e6b0740198ca2f5cb9ee465cee92b34b025"
+  version "1.2.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.2.0/dev-nginx.tar.gz"
+  sha256 "4a8dcd01c5f3e1d88947f763f8f5b4f9090ac2096c713361a3c25227338f274d"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
Releases https://github.com/guardian/dev-nginx/releases/tag/v1.2.0.