### PR TITLE
install vpn-slice once 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,14 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Install local casks with Homebrew"
-        # macos-latest comes with node 14 installed,
+        # macos-latest comes with node 14 and awscli installed,
         # we need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`
         # see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         # see https://github.com/Homebrew/brew/issues/1505
         run: |
           brew unlink node@14
+          rm /usr/local/bin/aws
+          rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
           brew cask install Casks/gu-base.rb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Install local casks with Homebrew"
-        # macos-latest comes with node 12 installed,
+        # macos-latest comes with node 14 installed,
         # we need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`
         # see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         # see https://github.com/Homebrew/brew/issues/1505
         run: |
-          brew unlink node@12
+          brew unlink node@14
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
           brew cask install Casks/gu-base.rb

--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -1,18 +1,18 @@
 class GuVpn < Formula
-  
+
     desc "Formula for guardian vpn access using openconnect and vpn-slice script"
     homepage "https://github.com/guardian/homebrew-devtools"
     version "1"
     url "https://raw.githubusercontent.com/guardian/homebrew-devtools/master/scripts/run-vpn.sh"
     sha256 "dcf29bd392ce23e1987a274bd3f6d058fdd3cd88047728e99ff114a9336f3f40"
-  
+
     depends_on "openconnect"
     depends_on "bind"
-    depends_on "pyenv"
-  
+    depends_on "vpn-slice"
+
     def install
         mv "run-vpn.sh", "gvpn"
-        bin.install "gvpn"    
+        bin.install "gvpn"
     end
-  
+
   end

--- a/scripts/run-vpn.sh
+++ b/scripts/run-vpn.sh
@@ -19,11 +19,6 @@ DOMAINS=(
 
 DOMAINS_STRING=$(join ' ' ${DOMAINS[@]})
 
-
-pyenv install 3.7.2 -s
-pyenv shell 3.7.2
-pip3 install vpn-slice -q --disable-pip-version-check
-
 echo ""
 echo "Setting up VPN for these domains: ${DOMAINS_STRING}"
 

--- a/scripts/run-vpn.sh
+++ b/scripts/run-vpn.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if [ "$EUID" -ne 0 ]; then
+  echo "This script needs to run as root. Please try again."
+  exit 1
+fi
+
 function join { local IFS="$1"; shift; echo "$*"; }
 
 DOMAINS=(


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add vpn-slice as a dependency of gu-vpn allowing it to be installed once [through brew](https://github.com/dlenski/vpn-slice#requirements) as opposed to each time `gvpn` is run. This makes `gvpn` that much faster.

Also checks that the script was run as root and fails fast otherwise; see https://github.com/dlenski/vpn-slice/issues/19.

Lastly, adjusts CI as the node version that comes in the virtual environment has [moved on](https://github.com/actions/virtual-environments/blob/911f1685c48bf1c1c1578aaf232469a674398c78/images/macos/macos-10.15-Readme.md#language-and-runtime) since the last time CI was run. We should work out how to automatically keep up, but that's a concern for another PR. Furthermore, `awscli` has also recently been added to the virtual environment, so remove that too.

There's an argument to be made that this script should no longer be used, however it's super helpful for those of us who have updated to BigSur w/out realising our VPN or AV clients don't yet fully support it (may or may not be me... 😅 ).