### PR TITLE
Remove unrar from gu-base as it's not in homebrew anymore

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -21,7 +21,6 @@ cask 'gu-base' do
   depends_on formula:  'htop'
   depends_on formula:  'mtr'
   depends_on formula:  'tree'
-  depends_on formula:  'unrar'
   depends_on formula:  'watch'
   depends_on formula:  'awscli'
   depends_on formula:  'nginx'


### PR DESCRIPTION
unrar no longer in brew
```Error: No available formula with the name "unrar".
==> Searching for a previously deleted formula (in the last month)...
unrar was deleted from homebrew/core in commit 3f8c7632a6:
  unrar: remove (incompatible license)
  See https://fedoraproject.org/wiki/Licensing:Unrar
```
