### PR TITLE
chore: Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,5 @@ jobs:
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
           brew tap adoptopenjdk/openjdk
           brew tap homebrew/cask-versions
+          brew update
           brew install --cask Casks/gu-base.rb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,5 @@ jobs:
           rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
+          brew tap adoptopenjdk/openjdk
           brew install --cask Casks/gu-base.rb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,4 @@ jobs:
           rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
-          brew cask install Casks/gu-base.rb
+          brew install --cask Casks/gu-base.rb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,4 +17,5 @@ jobs:
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
           brew tap adoptopenjdk/openjdk
+          brew tap homebrew/cask-versions
           brew install --cask Casks/gu-base.rb


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

CI is currently failing. This is because the brew cask CLI has changed from `brew cask install <name>` to `brew install --cask <name>`.

This change uses the updated syntax to install brew casks.

It also explicitly taps [`adoptopenjdk/openjdk`](https://github.com/AdoptOpenJDK/homebrew-openjdk#usage) and [`homebrew/cask-versions`](https://github.com/Homebrew/homebrew-cask-versions#usage) to install `adoptopenjdk8` and `firefox-developer-edition`, as instructed.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

CI should pass.