### PR TITLE
SSM v2.2.0

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "2.1.1"
-  url "https://github.com/guardian/ssm-scala/releases/download/v2.1.1/ssm.tar.gz"
-  sha256 "4c907d32c5b58f2f0af6f1119c2ef36fdbee571fdb5bf520b30f4e25b4465c09"
+  version "2.2.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v2.2.0/ssm.tar.gz"
+  sha256 "0bd26f95432d95f5ebdd52133bbff56cdb3451d1f010343acdf1ed4fad976acb"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
Update to SSM v2.2.0 

- https://github.com/guardian/ssm-scala/pull/127