### PR TITLE
SSM v2.3.0

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "2.2.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v2.2.0/ssm.tar.gz"
-  sha256 "0bd26f95432d95f5ebdd52133bbff56cdb3451d1f010343acdf1ed4fad976acb"
+  version "2.3.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v2.3.0/ssm.tar.gz"
+  sha256 "dfef888b9a1d21da4137cee1b73431ac538379856bcf8663a3c02cad3df1ea1d"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
https://github.com/guardian/ssm-scala/releases/tag/v2.3.0

