### PR TITLE
Remove mas, firefox, java, scala

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -8,8 +8,8 @@ cask 'gu-base' do
   stage_only true
 
   # main applications
+
   depends_on formula:  'openssl'
-  depends_on formula:  'mas'
   depends_on formula:  'wget'
   depends_on formula:  'ack'
   depends_on formula:  'jq'
@@ -27,8 +27,6 @@ cask 'gu-base' do
   depends_on formula:  'nginx'
 
   # dev langs
-  depends_on cask:     'adoptopenjdk/openjdk/adoptopenjdk8'
-  depends_on cask:     'gu-scala'
   depends_on formula:  'node'
   depends_on formula:  'yarn'
 
@@ -39,7 +37,6 @@ cask 'gu-base' do
   # gui apps
   depends_on cask: 'keepingyouawake'
   depends_on cask: 'iterm2'
-  depends_on cask: 'homebrew/cask-versions/firefox-developer-edition'
   depends_on cask: 'visualvm'
   depends_on cask: 'intellij-idea'
   depends_on cask: 'visual-studio-code'


### PR DESCRIPTION
## What does this change?
This PR removes a number of dependencies from the gu-base homebrew cask. Unfortunately they don't work, for reasons outlined below. The biggest blow here seems to be scala and java, which most developers will need.

 - mas: the default mas is [not supported on Mac OS 10.14 (mojave)](https://github.com/mas-cli/mas#-homebrew), which is still preinstalled on many machines. 

All the other removals are due to the inability to add more than one custom tap with strap (we use CUSTOM_HOMEBREW_TAP to add this repo as a custom tap - see strap docs [here](https://github.com/guardian/strap) )

 - firefox: firefox developer editions depends on the [homebrew-cask-versions custom tap](https://github.com/Homebrew/homebrew-cask-versions/blob/master/Casks/firefox-developer-edition.rb)
 - java - depends on the [adoptopenjdk custom tap](https://github.com/AdoptOpenJDK/homebrew-openjdk)
 - gu-scala - depends on java


Developers will be left to install java/scala by themselves, which is sad! We could help by creating a bash script to do it (similar to how [gu-vpn](https://github.com/guardian/homebrew-devtools/blob/master/Formula/gu-vpn.rb) works) so that people are able to type 'installjavascala' or something in their terminal and it will run. 

## How to test
Get a new laptop, run `brew-install gu-base` and see if it works

## How can we measure success?
The script will run without errors
