### PR TITLE
Remove mas due to lack of OS 10.14 support

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -9,7 +9,6 @@ cask 'gu-base' do
 
   # main applications
   depends_on formula:  'openssl'
-  depends_on formula:  'mas'
   depends_on formula:  'wget'
   depends_on formula:  'ack'
   depends_on formula:  'jq'


### PR DESCRIPTION
## What does this change?
Mas is 'A simple command line interface for the Mac App Store.' The mas homebrew core formula does [not support Mac OS 10.14 (mojave)](https://github.com/mas-cli/mas#-homebrew), which is still preinstalled on many machines. I propose we remove this tool and leave people to install it themselves if they want to. 

This came out of a report from a digital designer having problems with running this script on their Mojave machine. 

