### PR TITLE
fix: Fix issue with thrift formula

### DIFF
--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -21,11 +21,10 @@ class Thrift < Formula
   end
 
   bottle do
-    cellar :any
     rebuild 1
-    sha256 "f3bd35df2ba94af77f15a836668db5eb7dfc0d37c77a2f77bc6cc980e1524f27" => :sierra
-    sha256 "528061b3a3689341d76d76a7faaa6345100bbbadeb4055a26f1acb6377aad3ba" => :el_capitan
-    sha256 "7b1c9edc94356d9cb426237fab09143c64d2bb2a85d86f7d8236702fa110f90c" => :yosemite
+    sha256 cellar: :any, sierra:     "f3bd35df2ba94af77f15a836668db5eb7dfc0d37c77a2f77bc6cc980e1524f27"
+    sha256 cellar: :any, el_capitan: "528061b3a3689341d76d76a7faaa6345100bbbadeb4055a26f1acb6377aad3ba"
+    sha256 cellar: :any, yosemite:   "7b1c9edc94356d9cb426237fab09143c64d2bb2a85d86f7d8236702fa110f90c"
   end
 
   head do
@@ -78,12 +77,13 @@ class Thrift < Formula
     system "make", "install"
   end
 
-  def caveats; <<~EOS
-    To install Ruby binding:
-      gem install thrift
+  def caveats
+    <<~EOS
+      To install Ruby binding:
+        gem install thrift
 
-    To install PHP extension for e.g. PHP 5.5:
-      brew install homebrew/php/php55-thrift
-  EOS
+      To install PHP extension for e.g. PHP 5.5:
+        brew install homebrew/php/php55-thrift
+    EOS
   end
 end

--- a/Formula/thrift@0.14.rb
+++ b/Formula/thrift@0.14.rb
@@ -5,11 +5,10 @@ class ThriftAT014 < Formula
   sha256 "4138575fb31d9b9eb16aa520696abe4d6abc67060423d149d75a93426dddbc61"
 
   bottle do
-    cellar :any
-    sha256 "17605f1674a5bc1f374f13137db550c51181e7eebae59513444d0f46032a2a78" => :catalina
-    sha256 "ead278adf991ed6056b97806f5a7815f76340492d00b39801c863e907826a2ec" => :mojave
-    sha256 "f2a1fcbee158d5478f786a1ff7667c65061e15f8a0ebecdbc69e748c184cc8ef" => :high_sierra
-    sha256 "3b554722d5011a8aa1906046d4d65b3482a121baf36c737aca4de1d270171e42" => :sierra
+    sha256 cellar: :any, catalina:    "17605f1674a5bc1f374f13137db550c51181e7eebae59513444d0f46032a2a78"
+    sha256 cellar: :any, mojave:      "ead278adf991ed6056b97806f5a7815f76340492d00b39801c863e907826a2ec"
+    sha256 cellar: :any, high_sierra: "f2a1fcbee158d5478f786a1ff7667c65061e15f8a0ebecdbc69e748c184cc8ef"
+    sha256 cellar: :any, sierra:      "3b554722d5011a8aa1906046d4d65b3482a121baf36c737aca4de1d270171e42"
   end
 
   head do
@@ -18,9 +17,9 @@ class ThriftAT014 < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "bison" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "bison" => :build
   depends_on "boost"
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We've started seeing issues with the thrift formula:

```console
Calling `cellar` in a bottle block is disabled!
```

It looks like this is the result of a brew deprecation, which can be fixed with `brew style --fix`. I don't quite know what the deprecation is exactly, so haven't linked to it.

See:
  - https://github.com/aws/aws-sam-cli/issues/2803