### PR TITLE
bump dev-nginx to 1.3.0

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.2.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.2.0/dev-nginx.tar.gz"
-  sha256 "4a8dcd01c5f3e1d88947f763f8f5b4f9090ac2096c713361a3c25227338f274d"
+  version "1.3.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.3.0/dev-nginx.tar.gz"
+  sha256 "4b0667c3e9ce783f86350d52cbab3714f4e9bfbb9ff157ec9fa1e3c31e207159"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
As per https://github.com/guardian/dev-nginx/releases/tag/v1.3.0

see also https://github.com/guardian/dev-nginx/pull/25
