### PR TITLE
fix: Fix path in `gu-vpn.rb` after renaming of the default branch

### DIFF
--- a/Formula/gu-vpn.rb
+++ b/Formula/gu-vpn.rb
@@ -3,7 +3,7 @@ class GuVpn < Formula
     desc "Formula for guardian vpn access using openconnect and vpn-slice script"
     homepage "https://github.com/guardian/homebrew-devtools"
     version "1"
-    url "https://raw.githubusercontent.com/guardian/homebrew-devtools/master/scripts/run-vpn.sh"
+    url "https://raw.githubusercontent.com/guardian/homebrew-devtools/main/scripts/run-vpn.sh"
     sha256 "e1973a1fe604c367a8349d6044aefeaf51d3ba3400d05dae7833515da0ff0b90"
 
     depends_on "openconnect"


### PR DESCRIPTION
Fixes https://github.com/guardian/homebrew-devtools/issues/73.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates the path after the renaming of the default branch.