### PR TITLE
bump dev-nginx to 1.4.0

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.3.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.3.0/dev-nginx.tar.gz"
-  sha256 "4b0667c3e9ce783f86350d52cbab3714f4e9bfbb9ff157ec9fa1e3c31e207159"
+  version "1.4.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.4.0/dev-nginx.tar.gz"
+  sha256 "2ffc6e35f2485ecfa1d00bf8eabc17d8c9e18a8ce25d57b0e5526335814eba08"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
As per https://github.com/guardian/dev-nginx/releases/tag/v1.4.0

see also guardian/dev-nginx#26
