### PR TITLE
feat: Add `fnm` to base set of tools we use

### DIFF
--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -29,6 +29,7 @@ cask 'gu-base' do
   depends_on cask:     'gu-scala'
   depends_on formula:  'node'
   depends_on formula:  'yarn'
+  depends_on formula:  'fnm'
 
   # guardian stuff
   depends_on formula:  'guardian/devtools/ssm'


### PR DESCRIPTION
`fnm` is an alternative to `nvm`. It's benefits over `nvm` include:
  - fast auto switching upon changing directories (via [`--use-on-cd`](https://github.com/Schniz/fnm#shell-setup))
  - official homebrew support (see https://github.com/nvm-sh/nvm#:~:text=Homebrew%20installation%20is%20not%20supported)

`fnm`'s API is largely the same as `nvm`'s, so to save muscle memory, we could create an alias. But you should never even need to type `fnm` as auto switching works so well!