### PR TITLE
Simplify `gu-base` to be a collection of core tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,5 @@ jobs:
           rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
-          brew tap adoptopenjdk/openjdk
-          brew tap homebrew/cask-versions
           brew update
           brew install --cask Casks/gu-base.rb

--- a/Casks/gu-base.rb
+++ b/Casks/gu-base.rb
@@ -1,5 +1,5 @@
-cask 'gu-base' do 
-  version '0.0.5'
+cask 'gu-base' do
+  version '0.0.6'
   sha256 :no_check
 
   name 'Guardian Base'
@@ -15,37 +15,23 @@ cask 'gu-base' do
   depends_on formula:  'bash-completion'
   depends_on formula:  'coreutils'
   depends_on formula:  'git'
-  depends_on formula:  'hub'
   depends_on formula:  'gnupg'
   depends_on formula:  'htop'
-  depends_on formula:  'mtr'
   depends_on formula:  'tree'
   depends_on formula:  'watch'
   depends_on formula:  'awscli'
   depends_on formula:  'nginx'
 
   # dev langs
-  depends_on cask:     'adoptopenjdk/openjdk/adoptopenjdk8'
   depends_on cask:     'gu-scala'
-  depends_on formula:  'node'
-  depends_on formula:  'yarn'
 
   # guardian stuff
   depends_on formula:  'guardian/devtools/ssm'
   depends_on formula:  'guardian/devtools/dev-nginx'
 
-  # gui apps
-  depends_on cask: 'keepingyouawake'
-  depends_on cask: 'iterm2'
-  depends_on cask: 'homebrew/cask-versions/firefox-developer-edition'
-  depends_on cask: 'visualvm'
-  depends_on cask: 'intellij-idea'
-  depends_on cask: 'visual-studio-code'
   depends_on cask: 'gpg-suite'
-  depends_on cask: 'postman'
-  depends_on cask: 'vlc'
-  depends_on cask: 'rectangle'
-  depends_on cask: 'licecap'
+
+  # This is a dependency of `guardian/devtools/ssm`
   depends_on cask: 'session-manager-plugin'
 
 end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# homebrew-devtools
-A homebrew tap containing dev tools for the Guardian
+# Guardian Developer Tools
+
+## Usage
+First, add the tap:
+
+```bash
+brew tap guardian/homebrew-devtools
+```
+
+Then, install the [casks](./Casks) and [formulae](./Formula).
+
+At a minimum, you should install `gu-base`:
+
+```bash
+brew install gu-base
+```
+
+## What is it?
+A collection of core developer tools used at the Guardian, 
+wrapped up in a [homebrew](https://brew.sh/) [tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap).
+
+There are numerous [casks](./Casks) and [formulae](./Formula) available.
+
+## What is it not?
+An opinionated list of tools or apps.
+
+There are many ways to manage Node (`nvm`, `fnm`, `asdf`, etc.) or Java (`coursier`, `sdkman`, `asdf` etc.).
+Similarly, there multiple browsers one can use (Google Chrome, Firefox, Opera, etc.).
+
+For this reason, rather than being prescriptive, we leave the choice up to the user.
+
+💡 It is recommended to install applications using `brew` as you can then create a `Brewfile` that can be checked into VCS, making it easier to set up a new machine.
+More information about this can be found [here](https://gist.github.com/ChristopherA/a579274536aab36ea9966f301ff14f3f).
+
+For example, to install IntelliJ, VS Code and Google Chrome, one can do:
+
+```bash
+brew install --cask intellij-idea
+brew install --cask visual-studio-code
+brew install --cask google-chrome
+```


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We don't strictly need to install a lot of the casks listed in `gu-base`, for example VLC. Additionally, we have not standardised on any particular version managers.

In this change, we strip down `gu-base` to the core tools we use and push the responsibility of installing applications to the user. This will reduce friction between tools one is familiar with and the tools `gu-base` installs.

The changes to the README can be seen [here](https://github.com/guardian/homebrew-devtools/blob/aa-simplify/README.md).

This will close #78 and #77.