### PR TITLE
ci: Fix CI following removal of Node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,14 +4,13 @@ jobs:
   install:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: "Install local casks with Homebrew"
-        # macos-latest comes with node 14 and awscli installed,
+        # macos-latest comes with awscli installed,
         # we need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`
         # see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
         # see https://github.com/Homebrew/brew/issues/1505
         run: |
-          brew unlink node@14
           rm /usr/local/bin/aws
           rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,5 +15,6 @@ jobs:
           rm /usr/local/bin/aws_completer
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
+          brew tap --repair
           brew update
           brew install --cask Casks/gu-base.rb


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Since https://github.com/guardian/homebrew-devtools/pull/79 `gu-base` does not install node, opting instead for self installation by the developer.

As such we can remove update the build. The removed line is also causing the build to fail on `main`, so win win!

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should pass.