### PR TITLE
bump dev-nginx to 1.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: [pull_request, workflow_dispatch]
 jobs:
   install:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       # macos-latest comes with awscli installed.
       # We need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: [pull_request, workflow_dispatch]
 jobs:
   install:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       # macos-latest comes with awscli installed.
       # We need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`.

--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.4.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.4.0/dev-nginx.tar.gz"
-  sha256 "2ffc6e35f2485ecfa1d00bf8eabc17d8c9e18a8ce25d57b0e5526335814eba08"
+  version "1.5.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.5.0/dev-nginx.tar.gz"
+  sha256 "aae01904e6c5430be9c3d50b3291e7d151fa341ef2a7ba13f5c7e91348cbc51b"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
As per https://github.com/guardian/dev-nginx/releases/tag/v1.5.0

see also guardian/dev-nginx#28
