### PR TITLE
Bump dev-nginx to v1.5.0 [freshly cloned repo]

### DIFF
--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.4.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.4.0/dev-nginx.tar.gz"
-  sha256 "2ffc6e35f2485ecfa1d00bf8eabc17d8c9e18a8ce25d57b0e5526335814eba08"
+  version "1.5.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.5.0/dev-nginx.tar.gz"
+  sha256 "aae01904e6c5430be9c3d50b3291e7d151fa341ef2a7ba13f5c7e91348cbc51b"
 
   depends_on "nginx"
   depends_on "mkcert"


### PR DESCRIPTION
Duplicate of #88 to try @shtukas's suggestion of a freshly cloned repo and see if the git conflict build failure disappears