### PR TITLE
Perform `git status`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,12 @@ jobs:
         run: |
           rm /usr/local/bin/aws
           rm /usr/local/bin/aws_completer
+          git status
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
+          git status
           brew tap --repair
+          git status
           brew update
+          git status
           brew install --cask Casks/gu-base.rb


### PR DESCRIPTION
## What does this change?
The build log of #88 contains:

```log
error: could not apply 1728e63... Merge 0da6e2d72a155a4802c6dd09262f749ac997fa03 into 02dd55250ec66d58337ac276f718186ac0c8a059
hint: Resolve all conflicts manually, mark them as resolved with
hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
hint: You can instead skip this commit: run "git rebase --skip".
hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
Could not apply 1728e63... Merge 0da6e2d72a155a4802c6dd09262f749ac997fa03 into 02dd55250ec66d58337ac276f718186ac0c8a059
```

Unsure why, let's perform `git status` to narrow the cause down.

## How to test
CI passing is the test.