### PR TITLE
ci: Split homebrew setup steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,17 +4,27 @@ jobs:
   install:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: "Install local casks with Homebrew"
-        # macos-latest comes with awscli installed,
-        # we need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`
-        # see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
-        # see https://github.com/Homebrew/brew/issues/1505
+      # macos-latest comes with awscli installed.
+      # We need to unlink it first otherwise brew will fail as it can't link the version installed by `gu-base`.
+      # See https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
+      # See https://github.com/Homebrew/brew/issues/1505
+      - name: "Patch Homebrew AWS CLI"
         run: |
           rm /usr/local/bin/aws
           rm /usr/local/bin/aws_completer
+
+      # Update homebrew _before_ checking out the branch to avoid git conflicts.
+      # The exact reasons why this is necessary are a little fuzzy.
+      # We've seen homebrew update the checked out code and cause git conflicts, which results in CI failing.
+      # See https://github.com/guardian/homebrew-devtools/pull/92.
+      - name: "Update Homebrew"
+        run: brew update
+
+      - uses: actions/checkout@v3
+
+      - name: "Install local casks with Homebrew"
+        run: |
           mkdir -p /usr/local/Homebrew/Library/Taps/guardian
           ln -s $PWD /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools
           brew tap --repair
-          brew update
           brew install --cask Casks/gu-base.rb

--- a/Formula/dev-nginx.rb
+++ b/Formula/dev-nginx.rb
@@ -1,9 +1,9 @@
 class DevNginx < Formula
   desc "Tools to configure a local development nginx to proxy our applications and services"
   homepage "https://github.com/guardian/dev-nginx"
-  version "1.4.0"
-  url "https://github.com/guardian/dev-nginx/releases/download/v1.4.0/dev-nginx.tar.gz"
-  sha256 "2ffc6e35f2485ecfa1d00bf8eabc17d8c9e18a8ce25d57b0e5526335814eba08"
+  version "1.5.0"
+  url "https://github.com/guardian/dev-nginx/releases/download/v1.5.0/dev-nginx.tar.gz"
+  sha256 "aae01904e6c5430be9c3d50b3291e7d151fa341ef2a7ba13f5c7e91348cbc51b"
 
   depends_on "nginx"
   depends_on "mkcert"

--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "2.3.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v2.3.0/ssm.tar.gz"
-  sha256 "dfef888b9a1d21da4137cee1b73431ac538379856bcf8663a3c02cad3df1ea1d"
+  version "2.4.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v2.4.0/ssm.tar.gz"
+  sha256 "66e1d75d7eafbcab4eb68909c7415c7aa7bc475d2e6aed9c1122744d56fed468"
 
   def install
     bin.install "ssm"

--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -3,7 +3,7 @@ class Ssm < Formula
   homepage "https://github.com/guardian/ssm-scala"
   version "2.4.0"
   url "https://github.com/guardian/ssm-scala/releases/download/v2.4.0/ssm.tar.gz"
-  sha256 "66e1d75d7eafbcab4eb68909c7415c7aa7bc475d2e6aed9c1122744d56fed468"
+  sha256 "d16deabe57596adbc242fe953b24d2962aa81178ee9ab9ddeb701b6581c6da22"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
> **Warning**
> I've cherry-picked the changes from #84 and #88 into this branch to confirm the changes to the CI process fixes things. Before merging this PR, these cherry-picks should be removed to follow [single responsibility changes](https://github.com/guardian/recommendations/blob/main/pull-requests.md).

## What does this change?
The builds in #84 and #88 are failing with messages that suggest a git conflict:

```log
Error: guardian/devtools/ssm: /usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools/Formula/ssm.rb:4: syntax error, unexpected <<, expecting end
<<<<<<< HEAD
^~
/usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools/Formula/ssm.rb:8: syntax error, unexpected ===, expecting end
=======
^~~
/usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools/Formula/ssm.rb:12: syntax error, unexpected >>, expecting end
>>>>>>> c7fbe61 (Merge dac26abe...
^~
/usr/local/Homebrew/Library/Taps/guardian/homebrew-devtools/Formula/ssm.rb:12: syntax error, unexpected tIDENTIFIER, expecting ')'
...ec66d58337ac276f718186ac0c8a059)
...^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Indeed, this is confirmed via #92, which demonstrates that somewhere in the build homebrew is making changes to the checked out code in a way that causes git conflicts. This results in the above error message being witnessed when we attempt to install from the checked out code.

In this change, we split the CI steps up, changing the ordering.

### Before
  1. Checkout branch
  2. Apply AWS CLI work-around
  3. Update homebrew
  4. Install from local file system

### After
  1. Apply AWS CLI work-around
  2. Update homebrew
  3. Checkout branch
  4. Install from local file system

This should guarantee that homebrew does not mutate the checked out branch, and therefore make the build more deterministic, and stable.

## How to test
Observe CI.

## How can we measure success?
The PRs #84 and #88 become mergeable.