### PR TITLE
Release giant-utils 0.3.0

### DIFF
--- a/Formula/giant-utils.rb
+++ b/Formula/giant-utils.rb
@@ -2,16 +2,16 @@ class GiantUtils < Formula
   arch = Hardware::CPU.intel? ? "" : "-aarch64"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/giant-utils/releases/download/v0.1.0/giant-utils_x86_64-apple-darwin_v0.1.0.tar.gz"
-    sha256 "b2c8235f5f715315d9074e4b79807568f5ad83c99965dd39c51ccb9e2df0b9bb"
+    url "https://github.com/guardian/giant-utils/releases/download/v0.3.0/giant-utils_x86_64-apple-darwin_v0.3.0.tar.gz"
+    sha256 "764b678a70e4fa5a9e61b605a222fe2c801a91dba039f2b018def20879bf3318"
   else
-    url "https://github.com/guardian/giant-utils/releases/download/v0.1.0/giant-utils_aarch64-apple-darwin_v0.1.0.tar.gz"
-    sha256 "ce214e594bb625c67745908203c55c0a37914cbe49cdf35b01b314d3947e1e2d"
+    url "https://github.com/guardian/giant-utils/releases/download/v0.3.0/giant-utils_aarch64-apple-darwin_v0.3.0.tar.gz"
+    sha256 "24fa6e35aa121bac1779d56813ec070ac9cb1480bebfea9aee82d1687e111b51"
   end
 
   desc "CLI tool for interacting with Giant"
   homepage "https://github.com/guardian/giant-utils"
-  version "0.1.0"
+  version "0.3.0"
 
   def install
     bin.install "giant-utils"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
updates urls and hashes, releasing [v0.3.0 of giant-utils](https://github.com/guardian/giant-utils/releases/tag/v0.3.0).
