### PR TITLE
feat: Add a new formula for DevX Logs

### DIFF
--- a/Formula/devx-logs.rb
+++ b/Formula/devx-logs.rb
@@ -1,0 +1,11 @@
+class DevxLogs < Formula
+  desc "A small tool to deep-link to Central ELK."
+  homepage "https://github.com/guardian/devx-logs"
+  version "0.0.1"
+  url "https://github.com/guardian/devx-logs/releases/download/cli-v0.0.1/devx-logs"
+  sha256 "1da5956140a126edb045e6edaf937aa1bc188ec6126da3455ba2ae27f2fe1aff"
+
+  def install
+    bin.install "devx-logs"
+  end
+end


### PR DESCRIPTION
Adds a new Homebrew formula for the DevX Logs CLI tool. See https://github.com/guardian/devx-logs/pull/36 for a description of this CLI tool.

Once merged, we'll be able to install DevX Logs CLI via:

```bash
brew tap guardian/homebrew-devtools
brew install guardian/devtools/devx-logs
```