### PR TITLE
Update bucket-blocker.rb to rename binary

### DIFF
--- a/Formula/bucket-blocker.rb
+++ b/Formula/bucket-blocker.rb
@@ -1,17 +1,17 @@
 class BucketBlocker < Formula
   desc "CLI tool for blocking public access to S3 buckets"
   homepage "https://github.com/guardian/bucket-blocker"
-  version "1.0.1"
+  version "1.1.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/bucket-blocker/releases/download/v1.0.1/bucketblocker_darwin-amd64.tar.gz"
-    sha256 "3387de6e79d6ba49b16e48b55b5c3b1ae888e0b426139b0feef58ab39e1a1cb8"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v1.1.0/bucket-blocker_darwin-amd64.tar.gz"
+    sha256 "94c6ead682bafd7f65c7bde248aa91571514f7136d117e751a1cae9165fe2fe3"
   else
-    url "https://github.com/guardian/bucket-blocker/releases/download/v1.0.1/bucketblocker_darwin-arm64.tar.gz"
-    sha256 "59d7286be3d5be04a89ce6e83870eda101d3a48045b3572f9a14ca7aedde7692"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v1.1.0/bucket-blocker_darwin-arm64.tar.gz"
+    sha256 "940770811f706e17e7a3afb894794671372bf7a66341a28dabb59c09af7cd8c9"
   end
 
   def install
-    bin.install "bucketblocker"
+    bin.install "bucket-blocker"
   end
 end


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The binary used to be called `bucketblocker`, now it's `bucket-blocker`

## How to test

Release and try via brew
