### PR TITLE
update grid-cli to new v1.6.0

### DIFF
--- a/Casks/grid-cli.rb
+++ b/Casks/grid-cli.rb
@@ -1,8 +1,8 @@
 cask "grid-cli" do
   arch arm: "arm64", intel: "x64"
-  version "1.5.1-eadc1d4"
-  sha256 arm:   "b08b02b9a772ee2b5aa51b966fb307f290b09457f56e41c57586c8aa633bb21f",
-         intel: "2206c20626bfd87e0cadfccfe0bf958d5e711aa49da9f8c7fb3c3935bfc63b23"
+  version "1.6.0-1d376b2"
+  sha256 arm:   "2a745aaf80af41283c149534ebed39da11b774649a246184e48562fba86ce328",
+         intel: "6171632e32d6c45b2a35e6dcc9868f876de0609c886d506a4fb38e9dd3c2cd53"
 
   url "https://github.com/guardian/grid-cli/releases/download/v#{version.sub(%r{-\w+}, '')}/grid-v#{version}-darwin-#{arch}.tar.xz"
   name "grid-cli"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the grid-cli cask to the latest released version https://github.com/guardian/grid-cli/releases/tag/v1.6.0

**auto merge on**

