### PR TITLE
Update bucket-blocker.rb to version 2

### DIFF
--- a/Formula/bucket-blocker.rb
+++ b/Formula/bucket-blocker.rb
@@ -1,14 +1,14 @@
 class BucketBlocker < Formula
   desc "CLI tool for blocking public access to S3 buckets"
   homepage "https://github.com/guardian/bucket-blocker"
-  version "1.1.0"
+  version "2.0.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/bucket-blocker/releases/download/v1.1.0/bucket-blocker_darwin-amd64.tar.gz"
-    sha256 "94c6ead682bafd7f65c7bde248aa91571514f7136d117e751a1cae9165fe2fe3"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.0/bucket-blocker_darwin-amd64.tar.gz"
+    sha256 "619d5e51d5fe31c770e68631d402572e7ae4cd425dc7626736ec02814572d8a3"
   else
-    url "https://github.com/guardian/bucket-blocker/releases/download/v1.1.0/bucket-blocker_darwin-arm64.tar.gz"
-    sha256 "940770811f706e17e7a3afb894794671372bf7a66341a28dabb59c09af7cd8c9"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.0/bucket-blocker_darwin-arm64.tar.gz"
+    sha256 "d2be1f5b959cfeb3a2bab7679f5de98bf5b3c01fac5412a130f94bf355df4dd9"
   end
 
   def install

--- a/Formula/bucket-blocker.rb
+++ b/Formula/bucket-blocker.rb
@@ -1,14 +1,14 @@
 class BucketBlocker < Formula
   desc "CLI tool for blocking public access to S3 buckets"
   homepage "https://github.com/guardian/bucket-blocker"
-  version "2.0.0"
+  version "2.0.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.0/bucket-blocker_darwin-amd64.tar.gz"
-    sha256 "619d5e51d5fe31c770e68631d402572e7ae4cd425dc7626736ec02814572d8a3"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.1/bucket-blocker_darwin-amd64.tar.gz"
+    sha256 "a04ba2dd7e122984afeb63a9ae49770016ab8f725b0b475ef43eb0f833674a5f"
   else
-    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.0/bucket-blocker_darwin-arm64.tar.gz"
-    sha256 "d2be1f5b959cfeb3a2bab7679f5de98bf5b3c01fac5412a130f94bf355df4dd9"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.1/bucket-blocker_darwin-arm64.tar.gz"
+    sha256 "6be918db4e3990e98ecb25e6474ecabb1ec2d7f5a589e488167071d0d813e136"
   end
 
   def install


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the bucket blocker tool to use --execute instead of --dry-run

## How to test

Download the tar using the new URL. Verify the SHA sum [here](https://github.com/guardian/bucket-blocker/actions/runs/9776969895)