### PR TITLE
Release ingress-inquisition on brew

### DIFF
--- a/Formula/bucket-blocker.rb
+++ b/Formula/bucket-blocker.rb
@@ -1,14 +1,14 @@
 class BucketBlocker < Formula
   desc "CLI tool for blocking public access to S3 buckets"
-  homepage "https://github.com/guardian/bucket-blocker"
-  version "2.0.1"
+  homepage "https://github.com/guardian/fsbp-tools"
+  version "2.2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.1/bucket-blocker_darwin-amd64.tar.gz"
-    sha256 "a04ba2dd7e122984afeb63a9ae49770016ab8f725b0b475ef43eb0f833674a5f"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.2.0/bucket-blocker_darwin-amd64.tar.gz"
+    sha256 "747bc5a69f262422fac0ae9c4f546d18594813d5791a2ad1e3aa2e3712b929e9"
   else
-    url "https://github.com/guardian/bucket-blocker/releases/download/v2.0.1/bucket-blocker_darwin-arm64.tar.gz"
-    sha256 "6be918db4e3990e98ecb25e6474ecabb1ec2d7f5a589e488167071d0d813e136"
+    url "https://github.com/guardian/bucket-blocker/releases/download/v2.2.0/bucket-blocker_darwin-arm64.tar.gz"
+    sha256 "cd1ffa944d4f7c01894389affd92567b80341bd648eed087d0d170aaea708c3a"
   end
 
   def install

--- a/Formula/ingress-inquisition.rb
+++ b/Formula/ingress-inquisition.rb
@@ -1,0 +1,18 @@
+class IngressInquisition < Formula
+    desc "CLI tool for deleting default security groups on default VPCs in AWS"
+    homepage "https://github.com/guardian/fsbp-tools"
+    version "2.2.0"
+  
+    if Hardware::CPU.intel?
+      url "https://github.com/guardian/fsbp-tools/releases/download/v2.2.0/ingress-inquisition_darwin-amd64.tar.gz"
+      sha256 "611c795700462d23f4644fcbc5f5e446d25f9a8557b6cb1737c6d3d1a12287bd"
+    else
+      url "https://github.com/guardian/fsbp-tools/releases/download/v2.2.0/ingress-inquisition_darwin-arm64.tar.gz"
+      sha256 "b22cff6f78f0c14a59e8ed0cfa05cac20fffc1914be5f177fedb8d064c3301fe"
+    end
+  
+    def install
+      bin.install "ingress-inquisition"
+    end
+  end
+  


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Introduces ingress inquisition, which scans for and deletes violations of [EC2.2](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2) IN AWS Security Hub. Essentially, default VPCs should not be configured with security groups.
- Updates bucket-blocker to v2.2.0. These two tools come from the same repo as they share a lot of code, so their versions should be updated in tandem.




## How to test

- Double check the hashes (`sha256`) in the .rb files are correct by comparing them to the annotations of this [action run](https://github.com/guardian/fsbp-tools/actions/runs/10679708049)
- Verify you can download the archive file from the new URLs in the PR

## How can we measure success?

EC2.2 violations go down
