### PR TITLE
Bump ssm-scala to latest version (3.6.0)

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "3.4.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v3.4.0/ssm.tar.gz"
-  sha256 "5827360afc3de3eb05dc1a3d810be85a658f779d1588de3a51f9fdcc64fbde0a"
+  version "3.6.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v3.6.0/ssm.tar.gz"
+  sha256 "4f7a98fc8af3fed5c0e389328e1e2ba6f5ac6d5e420d72d32f761285837bb502"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps ssm-scala to the latest version, which includes a number of dependency version updates.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Installing the latest version of ssm-scala from homebrew should give v3.6.0
