### PR TITLE
Bump ssm-scala to v3.7.0

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "3.6.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v3.6.0/ssm.tar.gz"
-  sha256 "4f7a98fc8af3fed5c0e389328e1e2ba6f5ac6d5e420d72d32f761285837bb502"
+  version "3.7.0"
+  url "https://github.com/guardian/ssm-scala/releases/download/v3.7.0/ssm.tar.gz"
+  sha256 "eb72dde1cca41dff32a243072e782f769795a1d2c84f5d31b36dfdd52f7179d3"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps ssm-scala to the latest version, v3.7.0.

More information is on the release notes:
https://github.com/guardian/ssm-scala/releases/tag/v3.7.0