### PR TITLE
Update self-assessment version

### DIFF
--- a/Formula/self-assessment.rb
+++ b/Formula/self-assessment.rb
@@ -1,14 +1,14 @@
 class SelfAssessment < Formula
   desc "CLI tool for generating a report of authored and reviewed Github pull requests, as well as an optional report of Trello cards"
   homepage "https://github.com/guardian/self-assessment"
-  version "2.1.0"
+  version "2.2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/self-assessment/releases/download/v2.1.0/self-assessment_x86_64-apple-darwin_v2.1.0.tar.gz"
-    sha256 "08d8496bfb1cb971cee7fcd0e20aa048c440784bf2ab72abcf895087b9dffeeb"
+    url "https://github.com/guardian/self-assessment/releases/download/v2.2.0/self-assessment_x86_64-apple-darwin_v2.2.0.tar.gz"
+    sha256 "8ee31fd1665165340d681b3389ba9d6bfc9477fe67f109b924c4e4ab0de67d79"
   else
-    url "https://github.com/guardian/self-assessment/releases/download/v2.1.0/self-assessment_aarch64-apple-darwin_v2.1.0.tar.gz"
-    sha256 "7de21c1ec079842adab71c8dc51e989a2a5f7956103a40a099c280d83805ac08"
+    url "https://github.com/guardian/self-assessment/releases/download/v2.2.0/self-assessment_aarch64-apple-darwin_v2.2.0.tar.gz"
+    sha256 "ce9d34b38b142ef8c9a9f46bf415641fba58b7bc90c2b7dff293d9e664dabef5"
   end
 
   def install


### PR DESCRIPTION
## What does this change?

Update with the [latest release of assessment tool](https://github.com/guardian/self-assessment/releases/tag/v2.2.0).

 
![Screenshot 2025-02-03 at 11 40 10](https://github.com/user-attachments/assets/4d606ebd-7c15-4621-9f25-ca17ee952fb5)
