### PR TITLE
feat(devx-logs): Release v0.0.2

### DIFF
--- a/Formula/devx-logs.rb
+++ b/Formula/devx-logs.rb
@@ -1,9 +1,9 @@
 class DevxLogs < Formula
   desc "A small tool to deep-link to Central ELK."
   homepage "https://github.com/guardian/devx-logs"
-  version "0.0.1"
-  url "https://github.com/guardian/devx-logs/releases/download/cli-v0.0.1/devx-logs"
-  sha256 "1da5956140a126edb045e6edaf937aa1bc188ec6126da3455ba2ae27f2fe1aff"
+  version "0.0.2"
+  url "https://github.com/guardian/devx-logs/releases/download/cli-v0.0.2/devx-logs"
+  sha256 "9b984678cdaf14eff989440fb567e1bd46d5994592f49ae40cc260b366f02c66"
 
   def install
     bin.install "devx-logs"


### PR DESCRIPTION
Updates `devx-logs` to v0.0.2. See https://github.com/guardian/devx-logs/releases/tag/cli-v0.0.2.
