### PR TITLE
Roll ssm back to v3.7.1

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "3.8.0"
-  url "https://github.com/guardian/ssm-scala/releases/download/v3.8.0/ssm.tar.gz"
-  sha256 "04590dbb6fd4b11d5c7dc7a189b2a4dc9f75054c31d6a866266824b388ac949a"
+  version "3.7.1"
+  url "https://github.com/guardian/ssm-scala/releases/download/v3.7.1/ssm.tar.gz"
+  sha256 "84682ff0a05dcdc272e5d9fc2a7f26e79fe2505190d1d05cd50f2d4594e19c0b"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
#117 seems to have a bug introduced during the [upgrade to AWS SDK v2](https://github.com/guardian/ssm-scala/pull/483).

Rolling back until we've fixed it.
