### PR TITLE
bump ssm-scala to 3.8.1

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,9 +1,9 @@
 class Ssm < Formula
   desc "ssh replacement: CLI program that wraps SSM's EC2 Run Command"
   homepage "https://github.com/guardian/ssm-scala"
-  version "3.7.1"
-  url "https://github.com/guardian/ssm-scala/releases/download/v3.7.1/ssm.tar.gz"
-  sha256 "84682ff0a05dcdc272e5d9fc2a7f26e79fe2505190d1d05cd50f2d4594e19c0b"
+  version "3.8.1"
+  url "https://github.com/guardian/ssm-scala/releases/download/v3.8.1/ssm.tar.gz"
+  sha256 "f379a756680f7f0667b2b4a8e422562775af45bc3a7d7a765cf3fcbe66326663"
 
   def install
     bin.install "ssm"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps ssm-scala to 3.8.1 to include patch making AWS SDK work with v3.8.0 https://github.com/guardian/ssm-scala/pull/492
