### PR TITLE
Update self-assessment to v2.2.1

### DIFF
--- a/Formula/self-assessment.rb
+++ b/Formula/self-assessment.rb
@@ -1,14 +1,14 @@
 class SelfAssessment < Formula
   desc "CLI tool for generating a report of authored and reviewed Github pull requests, as well as an optional report of Trello cards"
   homepage "https://github.com/guardian/self-assessment"
-  version "2.2.0"
+  version "2.2.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/guardian/self-assessment/releases/download/v2.2.0/self-assessment_x86_64-apple-darwin_v2.2.0.tar.gz"
-    sha256 "8ee31fd1665165340d681b3389ba9d6bfc9477fe67f109b924c4e4ab0de67d79"
+    url "https://github.com/guardian/self-assessment/releases/download/v2.2.1/self-assessment_x86_64-apple-darwin_v2.2.1.tar.gz"
+    sha256 "16f6f49a5aaa8e2aae15f87c1185c2003dbf211065c0aedbbf67b5f850380e2a"
   else
-    url "https://github.com/guardian/self-assessment/releases/download/v2.2.0/self-assessment_aarch64-apple-darwin_v2.2.0.tar.gz"
-    sha256 "ce9d34b38b142ef8c9a9f46bf415641fba58b7bc90c2b7dff293d9e664dabef5"
+    url "https://github.com/guardian/self-assessment/releases/download/v2.2.1/self-assessment_aarch64-apple-darwin_v2.2.1.tar.gz"
+    sha256 "4f3e6daacbff331bda2080a82c17867e9a1442744053b333809915c386ee9e89"
   end
 
   def install


### PR DESCRIPTION
## What does this change?
Update to self assessment tool to the [latest release](https://github.com/guardian/self-assessment/releases/tag/v2.2.1).
I've run [`make_release.sh`](https://github.com/guardian/self-assessment/blob/abf2bffc136a832187c1208f7c85f5bb2ac3b530/scripts/make_release.sh#L24) locally and uploaded assets to the release above.

<img width="844" height="198" alt="Screenshot 2026-02-25 at 17 06 30" src="https://github.com/user-attachments/assets/f9bc1e8d-4bd3-43d5-8873-ad93e4a7d284" />


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Confirm hashes by running 
- `curl -L --silent https://github.com/guardian/self-assessment/releases/download/v2.2.1/self-assessment_aarch64-apple-darwin_v2.2.1.tar.gz | shasum -a 256`
- `curl -L --silent https://github.com/guardian/self-assessment/releases/download/v2.2.1/self-assessment_x86_64-apple-darwin_v2.2.1.tar.gz | shasum -a 256`